### PR TITLE
Moved 'deminout' command before 'opt_expr'.

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -228,10 +228,10 @@ struct SynthRapidSiliconPass : public ScriptPass {
             run("proc");
             run("flatten");
             run("tribuf -logic");
+            run("deminout");
             run("opt_expr");
             run("opt_clean");
             run("check");
-            run("deminout");
             run("opt -nodffe -nosdff");
             run("fsm");
             run("opt -sat");


### PR DESCRIPTION
This change doesn't have any impact on the QoR of All_lut suite, but it fixes the incorrect inout port transformation to regular in or out port.
The comparison QoR sheet is attached.
[All_lut_deminout_moved.xlsx](https://github.com/RapidSilicon/yosys-rs-plugin/files/8198628/All_lut_deminout_moved.xlsx)

