### PR TITLE
Fixed 'dffs' unit-test.

### DIFF
--- a/tests/dffs/dffs.tcl
+++ b/tests/dffs/dffs.tcl
@@ -63,7 +63,9 @@ synth_rs -tech genesis -goal area -de -top my_dffs_p
 yosys cd my_dffs_p
 stat
 select -assert-count 1 t:dffsre
-select -assert-count 1 t:\$lut
+# Without 'abc -dff' pass LUT count is 1.
+#select -assert-count 1 t:\$lut
+select -assert-count 3 t:\$lut
 design -reset
 
 # DFFS (negedge SET)
@@ -80,7 +82,9 @@ synth_rs -tech genesis -goal area -de -top my_dffse_p
 yosys cd my_dffse_p
 stat
 select -assert-count 1 t:dffsre
-select -assert-count 1 t:\$lut
+# Without 'abc -dff' pass LUT count is 1.
+#select -assert-count 1 t:\$lut
+select -assert-count 3 t:\$lut
 design -reset
 
 # DFFSE (negedge SET)


### PR DESCRIPTION
This change is a result of the `abc -dff` pass [addition](https://github.com/RapidSilicon/yosys-rs-plugin/pull/23) which in average improved the QoR, however we need to investigate this LUT addition issue.