### PR TITLE
Added 'clock_enable_strategy' option to synth_rs. 

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -41,7 +41,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 59
+#define VERSION_PATCH 60
 
 enum Strategy {
     AREA,


### PR DESCRIPTION
The following has been done:

- Added `clock_enable_strategy` option to synth_rs.
- Added control of `opt_dff` `-nodffe` and `-nosdff` arguments.

The QoR of the changes will be added later.