### PR TITLE
Added BRAM post processing step.

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -48,7 +48,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 74
+#define VERSION_PATCH 75
 
 enum Strategy {
     AREA,


### PR DESCRIPTION
There are cases when it is not possible to map RAM into DFFs (multiclock RAMs) and to map RAM into GENESIS BRAM (incompatibility). This change addresses this cases. 

This PR fixes [GEMINIEDA-184](https://rapidsilicon.atlassian.net/browse/GEMINIEDA-184) and [GEMINIEDA-311](https://rapidsilicon.atlassian.net/browse/GEMINIEDA-311) Jiras.