### PR TITLE
Do not convert negative edge DFF chains to shift registers.

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -54,7 +54,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 98
+#define VERSION_PATCH 99
 
 enum Strategy {
     AREA,


### PR DESCRIPTION
By default the pass converts $_DFF_[NP]_ gates to $__SHREG_DFF_[NP]_ (both positive and negative polarity dffs to corresponding shift registers). This change will limit conversion to only positive edge.

The change fixes [EDA-830](https://rapidsilicon.atlassian.net/browse/EDA-830) Jira.