### PR TITLE
EDA-884: Swapped Read ports for TDP BRAM inference, adjusted costs.

### DIFF
--- a/genesis2/brams_new.txt
+++ b/genesis2/brams_new.txt
@@ -2,7 +2,7 @@ ram block $__RS_FACTOR_BRAM18_SDP {
     byte 9;
     abits 14;
     widths  1 2 4 9 18 global;
-	cost 1;
+	cost 129;
 	init any;
     port sr "A" {
         clock posedge;
@@ -19,7 +19,7 @@ ram block $__RS_FACTOR_BRAM36_SDP {
     byte 9;
     abits 15;
     widths  1 2 4 9 18 36 global;
-	cost 2;
+	cost 257;
 	init any;
     port sr "A" {
         clock posedge;
@@ -36,9 +36,9 @@ ram block $__RS_FACTOR_BRAM18_TDP {
 	byte 9;
     abits 14;
     widths  1 2 4 9 18 global;
-	cost 1;
+	cost 129;
 	init any;
-	port sr "A" {
+	port sr "C" {
         clock posedge "C1";
         rden;
         rdinit any;
@@ -47,7 +47,7 @@ ram block $__RS_FACTOR_BRAM18_TDP {
         clock posedge "C1";
         wrtrans all new;
     }
-	port sr "C" {
+	port sr "A" {
         clock posedge "C2";
         rden;
         rdinit any;
@@ -62,9 +62,9 @@ ram block $__RS_FACTOR_BRAM36_TDP {
 	byte 9;
     abits 15;
     widths  1 2 4 9 18 36 global;
-	cost 2;
+	cost 257;
 	init any;
-	port sr "A" {
+	port sr "C" {
         clock posedge "C1";
         rden;
         rdinit any;
@@ -73,7 +73,7 @@ ram block $__RS_FACTOR_BRAM36_TDP {
         clock posedge "C1";
         wrtrans all new;
     }
-	port sr "C" {
+	port sr "A" {
         clock posedge "C2";
         rden;
         rdinit any;


### PR DESCRIPTION
This PR fixes swapped ports for the TDP memories. Yosys initially infers ports with swapped indexes, so this change workarounds that issue. The [EDA-884](https://rapidsilicon.atlassian.net/browse/EDA-884) is fixed with this change.

The cost values are taken from the [Xilinx mapping file](https://github.com/YosysHQ/yosys/blob/master/techlibs/xilinx/brams_xc4v.txt). 