### PR TITLE
EDA-890: Fixed incorrect dff transformation.

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -54,7 +54,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 104
+#define VERSION_PATCH 105
 
 enum Strategy {
     AREA,


### PR DESCRIPTION
Added the "dfflegalize" pass call in "simplify" function call before calling "abs" pass, which will change only $_SDDFCE_* types of dff cells. The QoR comparison of the Golden_synth_rs_ade_with_bram_with_dsp suite with the reference run is attached (there is no any QoR difference)
[new_changes_with_dfflegalize.xlsx](https://github.com/RapidSilicon/yosys-rs-plugin/files/10382990/new_changes_with_dfflegalize.xlsx)
