### PR TITLE
EDA-402: Fixed 32/36 bit width BRAM initialization issue.

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -55,7 +55,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 109
+#define VERSION_PATCH 110
 
 enum Strategy {
     AREA,


### PR DESCRIPTION
When data width is greater than 18 bits reading is performed from  two 18K RAMs, so split Init bits to 2x18 bit pairs: first half is going to the first 18K RAM and the second half to the second 18k RAM. 