### PR TITLE
EDA-1229: Fixed DSP decomposition issue.

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -66,7 +66,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 128
+#define VERSION_PATCH 129
 
 
 enum Strategy {


### PR DESCRIPTION
This change fixes DSP inference issue which has been reported in the EDA-1229 Jira, however with this change the EDA-1229 Jira design is still blowing up the RAM because of the huge number of `$dff` and `$mux` cells. Please see the stats below:

```
8.98. Printing statistics.
 
 === cf_fft_4096_18 ===
 
    Number of wires:             340819
    Number of wire bits:         19309150
    Number of public wires:       58630
    Number of public wire bits:  3873788
    Number of memories:               0
    Number of memory bits:            0
    Number of processes:              0
    Number of cells:             229573
      $alu                          239
      $and                        67886
      $bmux                           1
      $dff                        53272
      $dffe                          31
      $eq                           468
      $logic_not                     65
      $macc                           4
      $mux                       106922
      $not                           39
      $or                            26
      $sdffe                        440
      RS_DSP_MULT                   172
      RS_TDP36K                       8

```
There is a need for the further investigation of the problem, but it is already clear that these huge number of `$and`, `$dff` and `$mux` cells are a result of 54 memory cells mapping on a logic (they have not been mapped on BRAM). I'll continue investigation to see why these memories are not mapped on BRAM.