### PR TITLE
fix EDA-1282

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -70,7 +70,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 135
+#define VERSION_PATCH 136
 
 
 enum Strategy {


### PR DESCRIPTION
we error out a message right after DFF legalize in case we see DFF with SR in GENESIS3.