### PR TITLE
Fix EDA 1146

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -70,7 +70,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 142
+#define VERSION_PATCH 143
 
 
 enum Strategy {


### PR DESCRIPTION
call "opt_expr full" even with -fast so that we do not have dangling net failing the packer. 

It may slightly change QoR in -fast mode.