### PR TITLE
EDA-1482 carry resource limit

### DIFF
--- a/genesis3/all_arith_map.v
+++ b/genesis3/all_arith_map.v
@@ -23,7 +23,7 @@ module _80_rs_alu (A, B, CI, BI, X, Y, CO);
 	output [Y_WIDTH-1:0] CO;
 
 
-	wire _TECHMAP_FAIL_ = Y_WIDTH <= 2;
+	wire _TECHMAP_FAIL_ = Y_WIDTH <= 2 || Y_WIDTH > MAX_CARRY_CHAIN;
 
 	(* force_downto *)
 	wire [Y_WIDTH-1:0] A_buf, B_buf;

--- a/genesis3/arith_map.v
+++ b/genesis3/arith_map.v
@@ -27,7 +27,7 @@ module _80_rs_alu (A, B, CI, BI, X, Y, CO);
 	output [Y_WIDTH-1:0] CO;
 
 
-	wire _TECHMAP_FAIL_ = Y_WIDTH <= 16;
+	wire _TECHMAP_FAIL_ = Y_WIDTH <= 16 || Y_WIDTH > MAX_CARRY_CHAIN;
 
 	(* force_downto *)
 	wire [Y_WIDTH-1:0] A_buf, B_buf;

--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -1737,7 +1737,7 @@ struct SynthRapidSiliconPass : public ScriptPass {
                             break;
                         }
                         case CarryMode::NO: {
-                            run(stringf("techmap -D MAX_CARRY_CHAIN=%u", max_carry_length));
+                            run("techmap");
                             break;
                         }
                     }


### PR DESCRIPTION
The following has been done:

- Added the `-max_device_carry_length` and `-max_carry_length` options to the `synth_rs` plugin