### PR TITLE
EDA-1552 Corrected the BRAM initialization issue

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -71,7 +71,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 154
+#define VERSION_PATCH 155
 
 
 enum Strategy {


### PR DESCRIPTION
This PR corrects the BRAM Initialization flow for ROM (with only read port) under EDA-1552.

Regards,