### PR TITLE
EDA-1587 Added the 18 bit MODE initialization for 36-SDP

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -71,7 +71,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 159
+#define VERSION_PATCH 160
 
 enum Strategy {
     AREA,


### PR DESCRIPTION
This PR adds the 18-bit correct initialization for BRAM under $__RS_FACTOR_BRAM36_SDP cell.
Regards, 