### PR TITLE
Added condition for missing param

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -104,7 +104,7 @@ PRIVATE_NAMESPACE_BEGIN
 // 3 - dsp inference
 // 4 - bram inference
 #define VERSION_MINOR 4
-#define VERSION_PATCH 214
+#define VERSION_PATCH 215
 
 enum Strategy {
     AREA,


### PR DESCRIPTION
In this PR I have added a condition to To check whether we have single write-port or dual write-ports if we have single write-port and multiple read ports then we use same param for both write-ports (B and D) otherwise we use respected params of each port, this is added to handle the correct merging of two 18-TDP RAMs (new_RS_primitives) having single write port with multiple read ports. The test case is LU32PEEng_ql design.