### PR TITLE
Updated the condition with a warning for (-keep_tribuf) flag

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -2476,7 +2476,7 @@ void abcDffOpt(int unmap_dff_ce, int n, int dfl)
 
                 run("tribuf -logic");
                 no_iobuf = false;
-                log_warning("Force/Overide -no_iobuf to FALSE.\n");
+                log_warning("Ignored -no_iobuf because -keep_tribuf is used.\n");
 
             }else { // defualt mode : we replace TRIBUF by plain logic
                 // specific Rapid Silicon merge with -rs_merge option

--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -583,6 +583,7 @@ struct SynthRapidSiliconPass : public ScriptPass {
             }
             if (args[argidx] == "-keep_tribuf") {
                 keep_tribuf = true;
+                no_iobuf = false;
                 continue;
             }
             if (args[argidx] == "-de_max_threads" && argidx + 1 < args.size()) {

--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -583,7 +583,6 @@ struct SynthRapidSiliconPass : public ScriptPass {
             }
             if (args[argidx] == "-keep_tribuf") {
                 keep_tribuf = true;
-                no_iobuf = false;
                 continue;
             }
             if (args[argidx] == "-de_max_threads" && argidx + 1 < args.size()) {
@@ -2476,6 +2475,8 @@ void abcDffOpt(int unmap_dff_ce, int n, int dfl)
             if(keep_tribuf) { //non defualt mode :we keep TRIBUF
 
                 run("tribuf -logic");
+                no_iobuf = false;
+                log_warning("Force/Overide -no_iobuf to FALSE.\n");
 
             }else { // defualt mode : we replace TRIBUF by plain logic
                 // specific Rapid Silicon merge with -rs_merge option


### PR DESCRIPTION
This PR updates the condition for OBUFT inference with a warning that **-no_iobuf** will be forced/overide as false incase the 
**-keep_tribuf** flag is provided.

Best Regards