### PR TITLE
Fixed wrong placement of init bits for TDP18K BRAM

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -1765,10 +1765,10 @@ void abcDffOpt(int unmap_dff_ce, int n, int dfl)
         else if (  port_width == BRAM_WIDTH_9) {
             set_parity = true;
         }
-        else if ( port_width == BRAM_WIDTH_18) {
+        else if ( (port_width == BRAM_WIDTH_18) && (port_data_width == BRAM_WIDTH_18)) {
             set_parity = true;
         }
-        else if ( port_width == 27) {
+        else if ((port_width == BRAM_WIDTH_36) && (port_data_width == 27)) {
             set_parity = true;
         }
         else if ( (port_width == BRAM_WIDTH_36) && (port_data_width == BRAM_WIDTH_36)) {


### PR DESCRIPTION
This PR includes a fix for TDP_RAM18KX2 bram initialization issue, which corrects the wrong init bit placement incase of 18 bit mode when we don't have parity bits.

Regards,