### PR TITLE
introducing new cleanup for EDA-2859

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -17,6 +17,8 @@
 #include <regex>
 #include <string>
 #include <strings.h>
+#include <chrono>
+
 
 #ifdef PRODUCTION_BUILD
 #include "License_manager.hpp"
@@ -244,6 +246,9 @@ struct SynthRapidSiliconPass : public ScriptPass {
         log("        Use a specific ABC script instead of the embedded one.\n");
         log("\n");
 #endif
+        log("    -post_cleanup\n");
+        log("        Performs a post synthesis netlist cleanup.\n");
+        log("\n");
         log("    -cec\n");
         log("        Use internal equivalence checking (ABC based) during optimization\n");
         log("        and dump Verilog after key phases.\n");
@@ -380,6 +385,7 @@ struct SynthRapidSiliconPass : public ScriptPass {
     string abc_script;
     bool cec;
     bool sec;
+    bool post_cleanup;
     bool new_tdp36k;
     bool new_dsp19x2;
     bool nodsp;
@@ -452,6 +458,7 @@ struct SynthRapidSiliconPass : public ScriptPass {
         no_sat = false;
         no_flatten = false;
         no_iobuf= false;
+        post_cleanup= false;
         nobram = false;
         new_tdp36k = false;
         new_dsp19x2 =false;
@@ -546,6 +553,10 @@ struct SynthRapidSiliconPass : public ScriptPass {
             }
             if (args[argidx] == "-no_iobuf") {
 				no_iobuf = true;
+				continue;
+			}
+            if (args[argidx] == "-post_cleanup") {
+				post_cleanup = true;
 				continue;
 			}
             if (args[argidx] == "-new_tdp36k") {
@@ -1203,6 +1214,798 @@ struct SynthRapidSiliconPass : public ScriptPass {
        Cell* nextCarryCell = co2cell[ciSignal];
 
        return (getCarryChainLength(nextCarryCell, co2cell, cell2ci, l+1));
+    }
+
+    bool isSimpleSig(RTLIL::SigSpec lhs) {
+
+        return (lhs.chunks().size() <= 1);
+    }
+
+    // Split up complex LHS into simple ones
+    //
+    void makeSimpleLHS() {
+
+      std::vector<RTLIL::SigSig> newConnections;
+
+      for (auto it = _design->top_module()->connections().begin(); 
+           it != _design->top_module()->connections().end(); ++it) {
+
+          RTLIL::SigSpec lhs = it->first;
+          RTLIL::SigSpec rhs = it->second;
+
+#if 0
+          if (!isSimpleSig(lhs)) {
+            log("TRANSFORM: assign ");
+            show_sig(lhs);
+            log(" = ");
+            show_sig(rhs);
+            log("\n");
+          }
+#endif
+
+          int offset = 0;
+
+          for (auto &chunk : lhs.chunks()) {
+
+#if 0
+              if (!isSimpleSig(lhs)) {
+                log("       assign ");
+                show_sig(chunk);
+                log(" = ");
+                show_sig(rhs.extract(offset, GetSize(chunk)));
+                log("\n");
+              }
+#endif
+
+              RTLIL::SigSig newConn = std::make_pair((SigSpec)chunk, 
+                                            rhs.extract(offset, GetSize(chunk)));
+   
+              offset += GetSize(chunk);
+     
+              newConnections.push_back(newConn);
+          }
+      }
+
+      _design->top_module()->connections_.clear();
+
+      for (auto &conn : newConnections) {
+
+          RTLIL::SigSpec lhs = conn.first;
+          RTLIL::SigSpec rhs = conn.second;
+
+          _design->top_module()->connect(lhs, rhs);
+      }
+
+      run("write_verilog -noexpr make_simple_lhs.v");
+    }
+
+    void split2bits() {
+
+        log("Split to bits ... \n");
+
+        // we need to split busses in ihe netlist to make sure the forward and backward
+        // traversals will work correctly. Indeed when we have mixed up of single bit 
+        // signals (ex: s[5]) and busses (ex: s[6:4]) it is extremely difficult to 
+        // handle some clean traversals. By having a single bit to single bit
+        // correspondance the traversals will behave correctly
+        //
+        run("splitnets -ports");
+
+        // Use "write_verilog -simple_lhs" to deal with complex LHS. It is costly
+        // in term of runtime so it would be better to fix it in "sig2sig" and avoid
+        // to call this part of the code.
+        // For '\LU32PEEng' we waste 150 seconds in this code and only 3 seconds to 
+        // extract clock domains. Fixing it in "sig2sig" will then reduce to 3 seconds
+        // the total extraction.
+
+        //#define USE_WRITE_VERILOG_SIMPLE_LHS
+
+        #ifdef USE_WRITE_VERILOG_SIMPLE_LHS
+
+            // "-simple-lhs" to have single bits lhs assignments 
+            //
+            run("write_verilog -noexpr -simple-lhs post_cleanup.v");
+            run("design -reset");
+
+            string readArgs = GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, SIM_LIB_CARRY_FILE) 
+                                        GET_FILE_PATH(GENESIS_3_DIR, LLATCHES_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, DFFRE_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, DFFNRE_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, LUT1_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, LUT2_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, LUT3_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, LUT4_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, LUT5_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, LUT6_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, CLK_BUF_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, O_BUF_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, I_BUF_SIM_FILE)
+                                        GET_FILE_PATH_RS_FPGA_SIM(GENESIS_3_DIR, DSP_38_SIM_FILE)
+                                        GET_FILE_PATH(GENESIS_3_DIR, BRAMS_SIM_NEW_LIB_FILE1)
+                                        GET_FILE_PATH(GENESIS_3_DIR, BRAMS_SIM_LIB_FILE);
+            run("read_verilog -lib -specify -nomem2reg" GET_FILE_PATH(COMMON_DIR, SIM_LIB_FILE) + readArgs);
+
+            run("read_verilog post_cleanup.v");
+
+        #else
+
+            makeSimpleLHS();
+
+        #endif
+
+    }
+
+    void disposeSig2Cells(dict<RTLIL::SigSpec, std::set<Cell*>*>& sig2CellsInFanout,
+                          dict<RTLIL::SigSpec, std::set<Cell*>*>& sig2CellsInFanin) {
+
+      for (auto elt : sig2CellsInFanout){
+         delete(elt.second);
+      }
+      for (auto elt : sig2CellsInFanin){
+         delete(elt.second);
+      }
+    }
+
+    void disposeSig2Sig(dict<RTLIL::SigSpec, std::set<RTLIL::SigSpec>*>& rhsSig2LhsSig) {
+
+      for (auto elt : rhsSig2LhsSig){
+         delete(elt.second);
+      }
+    }
+
+
+    // Look at all the top module cells and build up the 'sig2CellsInFanout' and
+    // 'sig2CellsInFanin' dictionaries.
+    // 'sig2CellsInFanout' : sig to cells it is driving
+    // 'sig2CellsInFanin' : sig to cells it is driving from
+    //
+    void sig2cells (dict<RTLIL::SigSpec, std::set<Cell*>*>& sig2CellsInFanout,
+                    dict<RTLIL::SigSpec, std::set<Cell*>*>& sig2CellsInFanin) {
+
+        int nbCells = 0;
+        int nbInputs = 0;
+        int nbOutputs = 0;
+
+        log("Building Sig2cells ... ");
+
+        auto startTime = std::chrono::high_resolution_clock::now();
+
+        for (auto cell : _design->top_module()->cells()) {
+
+            nbCells++;
+
+            for (auto &conn : cell->connections()) {
+
+                IdString portName = conn.first;
+                RTLIL::SigSpec actual = conn.second;
+                std::set<Cell*>* newSet;
+
+                // For each input port of the cell stores its corresponding actual sig net 
+                // that drives this cell through this port.
+                // So for each sig net we have the corresponding set of cells it is driving.
+                //
+                if (cell->input(portName)) {
+
+                    nbInputs++;
+
+                    if (!actual.is_chunk()) {
+
+                      for (auto it = actual.chunks().rbegin(); 
+                              it != actual.chunks().rend(); ++it) {
+
+                          RTLIL::SigSpec sub_actual = *it;
+
+                          if (sig2CellsInFanout.count(sub_actual)) {
+
+                              newSet = sig2CellsInFanout[sub_actual];
+
+                          } else {
+
+                              newSet = new std::set<Cell*>;
+                              sig2CellsInFanout[sub_actual] = newSet;
+                          }
+  
+                          newSet->insert(cell);
+  
+                      } // end for 
+
+                    } else {
+
+    #if 0
+                      if (1 || (cell->name == "_091_")) {
+                        log("Processing input %s of cell %s\n", portName.c_str(), 
+                            (cell->name).c_str());
+                        show_sig(actual);
+                        log("\n");
+                      }
+    #endif
+
+                      if (sig2CellsInFanout.count(actual)) {
+
+                        newSet = sig2CellsInFanout[actual];
+
+                      } else {
+
+                        newSet = new std::set<Cell*>;
+                        sig2CellsInFanout[actual] = newSet;
+                      }
+
+                      newSet->insert(cell);
+                    }
+
+                } else { // Cell output port case :
+                         // For each output port of the cell stores its corresponding 
+                         // actual sig net that is driven by this cell through this 
+                         // output port.
+                         // So for each sig net we have the corresponding set of cells 
+                         // that drives it.
+                         // Theoritically this set has only 1 Cell. If it has multiple 
+                         // cells then this means this sig net is multiply driven 
+                         // (which is not good !).
+
+                    nbOutputs++;
+
+#if 0
+                    if(cell->type == RTLIL::escape_id("TDP_RAM18KX2")) {
+                    }
+#endif
+
+                    if (!actual.is_chunk()) {
+
+                      for (auto it = actual.chunks().rbegin(); 
+                              it != actual.chunks().rend(); ++it) {
+
+                          RTLIL::SigSpec sub_actual = *it;
+
+                          if (sig2CellsInFanin.count(sub_actual)) {
+
+                              newSet = sig2CellsInFanin[sub_actual];
+
+                          } else {
+
+                              newSet = new std::set<Cell*>;
+                              sig2CellsInFanin[sub_actual] = newSet;
+                          }
+  
+                          newSet->insert(cell);
+  
+                      } // end for 
+
+                    } else {
+
+                      if (sig2CellsInFanin.count(actual)) { // should not happen ! Multiply driven case
+
+                        newSet = sig2CellsInFanin[actual];
+
+                      } else {
+
+                        newSet = new std::set<Cell*>;
+                        sig2CellsInFanin[actual] = newSet;
+                      }
+
+                      newSet->insert(cell);
+                    }
+                }
+            }
+        }       
+
+        #if 0
+            log("Processed %d cells\n", nbCells);
+            log("Processed %d inputs\n", nbInputs);
+            log("Processed %d outputs\n", nbOutputs);
+        #endif
+
+        auto endTime = std::chrono::high_resolution_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime);
+
+        float totalTime = elapsed.count() * 1e-9;
+
+        log(" [%.2f sec.]\n", totalTime);
+    }
+
+    int sigIsConstant(RTLIL::SigSpec sig) {
+
+       if (sig.is_chunk()) {
+           if ((sig.as_chunk()).wire == NULL) {
+              return 1;
+           }
+       }
+
+       return 0;
+    }
+
+
+    // Process the internal assignment of the form : assign lhs = rhs;
+    //
+    // Handle case where LHS is complex and is a concat of several signals like
+    //
+    // assign {lhsSig1, lhsSig2, lhsSig3, lhsSig4} = {rhsSig1, rhsSig2, rhsSig3, rhsSig4}.
+    //
+    // We will translate it into :
+    //    assign lhsSig1 = rhsSig1;
+    //    assign lhsSig2 = rhsSig2;
+    //    assign lhsSig3 = rhsSig3;
+    //    assign lhsSig4 = rhsSig4;
+    //
+    // Handle also case where we have constants in the RHS like :
+    //
+    // assign {lhsSig1, lhsSig2, lhsSig3, lhsSig4} = {2'b00, rhsSig3, rhsSig4}.
+    //
+    // We need to look at the constant width to make sure that there is a one to one
+    // correspondance between the lhsSig_i and rhsSig_i (called sub actuals).
+    // In this case we will generate only assignments for "lhsSig3", "lhsSig4" like : 
+    //
+    //    assign lhsSig3 = rhsSig3;
+    //    assign lhsSig4 = rhsSig4;
+    //
+    // The RHS constant assignments are not usefull for traversals.
+    //
+    void sig2sig(dict<RTLIL::SigSpec, std::set<RTLIL::SigSpec>*>& rhsSig2LhsSig,
+                 dict<RTLIL::SigSpec, RTLIL::SigSpec>& lhsSig2rhsSig)
+    {
+        log("Building Sig2sig ...   ");
+
+        auto startTime = std::chrono::high_resolution_clock::now();
+
+        for (auto it = _design->top_module()->connections().begin(); 
+            it != _design->top_module()->connections().end(); ++it) {
+
+            RTLIL::SigSpec lhs = it->first;
+            RTLIL::SigSpec rhs = it->second;
+
+            if (sigIsConstant(rhs)) {
+            continue;
+            }
+
+    #if 0
+            log("ASSIGN ");
+            show_sig(lhs);
+            log(" = ");
+            show_sig(rhs);
+            log("\n\n");
+    #endif
+
+            if (!lhs.is_chunk()) { // if the assign is an assignment of bus/slice
+
+              int misMatchCase = 0;
+
+              // This case needs to be handled. It is generally when we have a constant
+              // on several bits on RHS. If the constant is for instance 6'b000000 it counts 
+              // for 1 (element) instead of 6 (bits). So we would need to split the constant
+              // as well.
+              //
+              if (lhs.chunks().size() != rhs.chunks().size()) {
+
+                misMatchCase = 1;
+
+                auto rit = rhs.chunks().rbegin();
+        
+                long unsigned rhsSize = 0;
+
+                // Check if size mismatch is due to constant slices on the RHS
+                //
+                while (rit != rhs.chunks().rend()) {
+
+                    RTLIL::SigSpec sub_rhs = *rit;
+
+                    if (sigIsConstant(sub_rhs)) {
+
+                       rhsSize += (sub_rhs.as_chunk()).width;
+
+                    } else {
+
+                       rhsSize++;
+                    }
+
+                    rit++;
+                }
+
+                if (lhs.chunks().size() != rhsSize) {
+
+                   log("ERROR: Assignment with LHS and RHS of different sizes (%ld vs %ld)\n",
+                       lhs.chunks().size(), rhsSize);
+
+                   log("         assign ");
+                   show_sig(lhs);
+                   log(" = ");
+                   show_sig(rhs);
+                   log("\n");
+                   log_error("\n");
+
+                   // There is a true mismatch : we would need to investigate this case if this happens
+                   continue;
+                }
+
+    #if 0
+                log("         assign ");
+                show_sig(lhs);
+                log(" = ");
+                show_sig(rhs);
+                log("\n");
+
+                log("Computed LHS and RHS exact sizes : %ld vs %ld\n", lhs.chunks().size(), rhsSize);
+                getchar();
+    #endif
+              }
+
+              // Lhs and Rhs have exactly the same size !
+              //
+              auto lit = lhs.chunks().rbegin();
+              auto rit = rhs.chunks().rbegin();
+        
+              // RHS should have always less (misMatchCase) or equal sub actuals than LHS so 
+              // we check iteration exit on RHS.
+              //
+              while (rit != rhs.chunks().rend()) {
+
+                RTLIL::SigSpec sub_lhs = *lit;
+                RTLIL::SigSpec sub_rhs = *rit;
+
+                std::set<RTLIL::SigSpec>* fanout;
+
+                // If the 'sub_rhs" is a constant pass over it and iterate on the 'lhs' 
+                // the "constant width" number of time.
+                //
+                if (sigIsConstant(sub_rhs)) {
+
+                    int constSize = (sub_rhs.as_chunk()).width;
+
+                    while (constSize--) {
+                       lit++;
+                    }
+                    rit++;
+
+                    continue;
+                }
+
+                if (rhsSig2LhsSig.count(sub_rhs) == 0) {
+
+                    fanout = new std::set<RTLIL::SigSpec>;
+                    rhsSig2LhsSig[sub_rhs] = fanout;
+                }
+
+                fanout = rhsSig2LhsSig[sub_rhs];
+            
+                fanout->insert(sub_lhs); // add 'sub_lhs' in the fanout of 'sub_rhs'.
+
+                lhsSig2rhsSig[sub_lhs] = sub_rhs; // 'sub_lhs" has only one 'sub_rhs'
+
+                if (misMatchCase) {
+    #if 0
+                    log("SUB_ASSIGN ");
+                    show_sig(sub_lhs);
+                    log(" = ");
+                    show_sig(sub_rhs);
+                    log("\n\n");
+                    getchar();
+    #endif
+                }
+
+                lit++;
+                rit++;
+              }
+
+            } else { 
+
+              std::set<RTLIL::SigSpec>* fanout;
+
+              if (rhsSig2LhsSig.count(rhs) == 0) {
+
+                fanout = new std::set<RTLIL::SigSpec>;
+                rhsSig2LhsSig[rhs] = fanout;
+              }
+
+              fanout = rhsSig2LhsSig[rhs];
+            
+              fanout->insert(lhs); // add 'lhs' in the fanout of 'rhs'.
+                
+              lhsSig2rhsSig[lhs] = rhs; // 'lhs" has only one 'rhs'
+            }
+        }
+
+        auto endTime = std::chrono::high_resolution_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime);
+
+        float totalTime = elapsed.count() * 1e-9;
+
+        log(" [%.2f sec.]\n", totalTime);
+    }
+
+    // Recursive backward traversal going through the transitive fanin of signal 'sig'.
+    //
+    void backCleanRec(RTLIL::SigSpec& sig,
+                          dict<RTLIL::SigSpec, std::set<Cell*>*>& sig2CellsInFanin,
+                          dict<RTLIL::SigSpec, RTLIL::SigSpec>& lhsSig2RhsSig,
+                          std::set<Cell*> &visitedCells,
+                          std::set<RTLIL::SigSpec> &visitedSigSpec) {
+
+
+        if (sigIsConstant(sig)) {
+           return;
+        }
+
+        // return if already visited
+        //
+        if (visitedSigSpec.count(sig)) {
+           return;
+        }
+
+        visitedSigSpec.insert(sig);
+
+    #if 0
+        log("Backward Visit ");
+        show_sig(sig);
+        log("\n");
+    #endif
+
+        int nbDrivers = 0;
+
+        // If some cells are driving this 'sig' then go through them.
+        //
+        if (sig2CellsInFanin.count(sig)) {
+
+            // Get the cells that are driving this 'sig'
+            //
+            std::set<Cell*>* sigFanin = sig2CellsInFanin[sig];
+
+            // For all the cells driving this 'sig' process them.
+            //
+            // **WARNING ** : theoritically we should have only 1 driver cell, not more !
+            // otherwise this "sig" is multi-driven
+            //
+            for (std::set<Cell*>::iterator it = sigFanin->begin(); it != sigFanin->end(); it++) {
+
+               Cell* cell = *it;
+
+               if (visitedCells.count(cell)) {
+                  continue;
+               }
+
+               visitedCells.insert(cell);
+
+               nbDrivers++;
+
+               // We traverse the cell and continue recursivity through its input ports
+               //
+               for (auto &conn : cell->connections()) {
+
+                   IdString portName = conn.first;
+                   RTLIL::SigSpec actual = conn.second;
+            
+                   if (cell->input(portName)) {
+
+                      // Beware : the 'actual' can be a single signal or a concat of several
+                      // signals.
+                      //
+                      if (!actual.is_chunk()) { // if the 'actual' is a concat of sub actuals then
+                                                // propagate backward on each sub actual.
+
+                        for (auto it = actual.chunks().rbegin(); 
+                            it != actual.chunks().rend(); ++it) {
+   
+                            RTLIL::SigSpec sub_actual = *it;
+
+                            backCleanRec(sub_actual, sig2CellsInFanin, lhsSig2RhsSig, 
+                                             visitedCells, visitedSigSpec); 
+                        }
+
+                      } else { // otherwise propagate backward on the single actual
+
+                            backCleanRec(actual, sig2CellsInFanin, lhsSig2RhsSig, 
+                                             visitedCells, visitedSigSpec); 
+                      }
+                   }
+               } // end of processing all the cell connections
+
+            } // end of processing all the cells driving 'sig'
+
+        } // end of case where 'sig' is driven by some cells
+
+        // Now handle case where 'sig' is driven by assigns : assign sig = rhs
+        //
+        if (lhsSig2RhsSig.count(sig)) {
+
+           RTLIL::SigSpec rhs = lhsSig2RhsSig[sig];
+
+           backCleanRec(rhs, sig2CellsInFanin, lhsSig2RhsSig,
+                        visitedCells, visitedSigSpec);
+
+           nbDrivers++;
+        }
+
+        // Complain if 'sig' is multi-driven
+        //
+        if (nbDrivers > 1) {
+
+          RTLIL::Wire *wire = sig[0].wire;
+          std::string sig_name = wire->name.str();
+          log_warning("Signal '%s' has multiple drivers !\n", sig_name.c_str());
+        }
+    }
+
+    // Peform a backward traversal from the top module primary outputs and store
+    // all the visited cells and signals.
+    // Remove the non visited cells and signals as they are not observable from
+    // the primary outputs.
+    //
+    void backClean(dict<RTLIL::SigSpec, std::set<Cell*>*>& sig2CellsInFanin,
+                   dict<RTLIL::SigSpec, RTLIL::SigSpec>& lhsSig2RhsSig) {
+
+        std::set<Cell*> visitedCells;
+        std::set<RTLIL::SigSpec> visitedSigSpec;
+
+        auto startTime = std::chrono::high_resolution_clock::now();
+
+        for (auto wire : _design->top_module()->wires()) {
+
+           if (!wire->port_output) {
+             continue;
+           }
+
+           // Start from top module Primary Outputs (POs)
+           //
+           RTLIL::SigSpec po = wire;
+
+           backCleanRec(po, sig2CellsInFanin, lhsSig2RhsSig, 
+                            visitedCells, visitedSigSpec);
+        }
+
+        auto endTime = std::chrono::high_resolution_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime);
+
+        float totalTime = elapsed.count() * 1e-9;
+
+        log("Backward clean up ...  ");
+        log(" [%.2f sec.]\n", totalTime);
+
+
+        log("Before cleanup :\n");
+        run("stat");
+
+#if 1
+        // Remove unsused connections/ unused assigns. They are the ones
+        // with unsued LHS
+        //
+        pool<RTLIL::SigSig> newConnections;
+        int nbConnectionsToRemove = 0;
+
+        for (auto it = _design->top_module()->connections().begin(); 
+            it != _design->top_module()->connections().end(); ++it) {
+
+            RTLIL::SigSpec lhs = it->first;
+
+            if (visitedSigSpec.count(lhs)) {
+              newConnections.insert(*it);
+              continue;
+            }
+
+            nbConnectionsToRemove++;
+        }
+
+        _design->top_module()->connections_.clear();
+
+        for (auto conn : newConnections) {
+            _design->top_module()->connect(conn);
+            //_design->top_module()->connections_.push_back(conn);
+        }
+#endif
+
+        // remove unused wires
+        //
+        pool<RTLIL::Wire*> wiresToRemove;
+
+        for (auto wire : _design->top_module()->wires()) {
+
+           RTLIL::SigSpec sig = wire;
+
+           if (visitedSigSpec.count(sig)) {
+              continue;
+           }
+
+#if 0
+           log_warning("Not observable Signal : ");
+           show_sig(sig);
+           log("\n");
+#endif
+
+           RTLIL::Wire *w = sig[0].wire;
+
+#if 0
+           std::string sig_name = w->name.str();
+           log("   %s\n", sig_name.c_str());
+#endif
+
+           wiresToRemove.insert(w);
+        }
+
+        _design->top_module()->remove(wiresToRemove);
+
+        log(" --------------------------\n");
+        log("   Removed assigns : %d\n", nbConnectionsToRemove);
+        log("   Removed wires   : %lu\n", wiresToRemove.size());
+
+        // remove unused cells
+        //
+        std::set<Cell*> cellsToRemove;
+
+        for (auto cell : _design->top_module()->cells()) {
+
+          if (visitedCells.count(cell)) {
+            continue;
+          }
+
+          cellsToRemove.insert(cell);
+        }
+
+        log("   Removed cells   : %lu\n", cellsToRemove.size());
+        log(" --------------------------\n");
+
+        for (auto cell : cellsToRemove) {
+          //log("Removing cell '%s'\n", id(cell->name).c_str());
+          _design->top_module()->remove(cell);
+        }
+
+        log("After cleanup :\n");
+        run("stat");
+    }
+
+    // This functions will do a PO "observability" clean-up, e.g. any object not 
+    // participating in the top module Primary Outputs functionality will be 
+    // removed.
+    // NOTE: this pass will transform also the current design as it will bit 
+    // split it and transform complex LHS into simple LHS.
+    //
+    void design_cleanup() {
+
+        //run("design -save before_post_cleanup");
+
+        log("Post design clean up ... \n");
+
+        auto startTime = std::chrono::high_resolution_clock::now();
+
+        // we need to slit busses in ihe netlsi to make sure the forward and  bacward
+        // traversals will work correctly. Indeed when we have mixed up of single bit 
+        // signals (ex: s[5]) and busses (ex: s[6:4]) it is extremely difficult to 
+        // handle some clean traversals. By having a single bit to single bit
+        // correspondance the traversals will behave correctly
+        //
+        split2bits();
+
+        auto endTime = std::chrono::high_resolution_clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(endTime - startTime);
+
+        float totalTime = elapsed.count() * 1e-9;
+
+        log("\nSplit into bits ...    ");
+        log(" [%.2f sec.]\n", totalTime);
+
+        dict<RTLIL::SigSpec, std::set<Cell*>*> sig2CellsInFanout;
+        dict<RTLIL::SigSpec, std::set<Cell*>*> sig2CellsInFanin;
+
+        // Building connections dictionaries
+        //
+        // On cells connections
+        //
+        sig2cells(sig2CellsInFanout, sig2CellsInFanin);
+
+        dict<RTLIL::SigSpec, std::set<RTLIL::SigSpec>*> rhsSig2LhsSig;
+        dict<RTLIL::SigSpec, RTLIL::SigSpec> lhsSig2RhsSig;
+
+        // on simple assignments (assign lhs = rhs)
+        //
+        sig2sig(rhsSig2LhsSig, lhsSig2RhsSig);
+
+        //run("write_verilog -noexpr -simple-lhs before_design_cleanup.v");
+
+        // Perform the real clean up by doing a backward traversal from the POs.
+        //
+        backClean(sig2CellsInFanin, lhsSig2RhsSig);
+
+        // Dispose objects created with 'new' when building the dictionaries
+        //
+        disposeSig2Cells(sig2CellsInFanout, sig2CellsInFanin);
+        disposeSig2Sig(rhsSig2LhsSig);
+
     }
 
     void reportCarryChains() {
@@ -2827,8 +3630,11 @@ void Set_INIT_PlacementWithNoParity_mode(Cell* cell,RTLIL::Const mode) {
             log_error("Cannot map %d internal 3-states Abort Synthesis  \n",tri_nError);
         }
     }
+
     // Add error message when clock signal is used in expression EDA-2953
+    //
     void illegal_clk_connection(){
+
         for (auto cell : _design->top_module()->cells()){
             if (RTLIL::builtin_ff_cell_types().count(cell->type)){
                 if (cell->getPort(ID::CLK) == cell->getPort(ID::D)){
@@ -2836,11 +3642,13 @@ void Set_INIT_PlacementWithNoParity_mode(Cell* cell,RTLIL::Const mode) {
                     for (auto &it : cell->attributes) {
                         RTLIL_BACKEND::dump_const(buf, it.second);
                     }
-                    log_error("Use of clock signal '%s' in the expression is not supported %s\n", log_signal(cell->getPort(ID::CLK)),buf.str().c_str());
+                    log_error("Use of clock signal '%s' in the expression is not supported %s\n", 
+                              log_signal(cell->getPort(ID::CLK)),buf.str().c_str());
                 }
             }
         }
     }
+
     // Check if DLATCH has been found.
     // This is specific for Genesis3 since it does not support DLATCH   
     //
@@ -5070,7 +5878,16 @@ static void show_sig(const RTLIL::SigSpec &sig)
            string techMaplutArgs = GET_TECHMAP_FILE_PATH(GENESIS_3_DIR, LUT_FINAL_MAP_FILE);// LUTx Mapping
            run("techmap -map" + techMaplutArgs);
 #endif
-           run("opt_clean");
+        }
+
+        run("opt_clean");
+
+        run("stat");
+
+        // Eventually performs post synthesis clean up
+        //
+        if (post_cleanup){
+          design_cleanup();
         }
 
         if (check_label("blif")) {


### PR DESCRIPTION
Introducing new design cleanup replacing 'opt_clean'.
To invoke it at the 'synth_rs' command level we need to add **-post_cleanup** .
It will do a post clean up at the end of synthesis.
This pass can make a lot of changes so it would be important to test it on CGA by forcing this option on 'synth_rs" and see how it goes.