### PR TITLE
dump info to track design stats when entering synthesis and real core…

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -5125,8 +5125,21 @@ static void show_sig(const RTLIL::SigSpec &sig)
         }
 
         if (check_label("prepare")) {
+
             run(stringf("hierarchy -check %s", top_opt.c_str()));
+
             run("proc");
+
+            // Show the first design resources stat before
+            // starting anything.
+            //
+            run("design -save original");
+            run("flatten");
+            log("\n# -------------------- \n");
+            log("#  Design entry stats  \n");
+            log("# -------------------- \n");
+            run("stat");
+            run("design -load original");
             
             // Collect ports properties
             //
@@ -5992,6 +6005,10 @@ static void show_sig(const RTLIL::SigSpec &sig)
         }
 
         sec_report();
+
+        log("\n# -------------------- \n");
+        log("# Core Synthesis done \n");
+        log("# -------------------- \n");
     }
 
 } SynthRapidSiliconPass;


### PR DESCRIPTION
… synthesis end

@alaindargelas  I added two log messages in the synthesis flow to help to track current/future issues: 

1. First one states the design entry statistics : this is helpful to see if from Raptor version from Raptor version we enter with the same data. This is to track non determinism that can happen before synthesis. When we will see non determinism downward, we will check first this message to see if we have already some differences..
2. Final message message stating the real core synthesis end : this is to distinguish from the post synthesis tasks like netlist editing that kicks in after. For instance this helps to see runtime issues in netlist editing coming afterward the true synthesis flow, otherwise it looks that everything is in the synthesis flow.