### PR TITLE
comment obsrvability clean method to fix EDA-3136

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -8699,10 +8699,13 @@ static void show_sig(const RTLIL::SigSpec &sig)
         map_obuf_to_obuft(_design->top_module());
 
         // Eventually performs post synthesis clean up
-        //
-        if (post_cleanup){
-          obs_clean();
-        }
+        // commenting post cleanup as it might have some bugs.
+        // Bugs could be fixed in December, 2024 release.
+
+        // if (post_cleanup){
+        //   obs_clean();
+        // }
+
 
         _design->sort();
 


### PR DESCRIPTION
Temporarly commenting the obs_clean method, as it could be buggy, will fix it in next release