### PR TITLE
Revert "comment obsrvability clean method to fix EDA-3136"

### DIFF
--- a/src/synth_rapidsilicon.cc
+++ b/src/synth_rapidsilicon.cc
@@ -8720,13 +8720,10 @@ static void show_sig(const RTLIL::SigSpec &sig)
         map_obuf_to_obuft(_design->top_module());
 
         // Eventually performs post synthesis clean up
-        // commenting post cleanup as it might have some bugs.
-        // Bugs could be fixed in December, 2024 release.
-
-        // if (post_cleanup){
-        //   obs_clean();
-        // }
-
+        //
+        if (post_cleanup){
+          obs_clean();
+        }
 
         _design->sort();
 


### PR DESCRIPTION
Reverts os-fpga/yosys-rs-plugin#399

@awaisabbas006 when you made this PR, you didn't run the GJC designs.
Many design fail compilation because of this change.
Please do the change locally, run the designs, and find a fix for those designs that work when the obs_clean is commented out.
